### PR TITLE
Explicitly link unix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name OSCADml)
  (public_name OSCADml)
- (libraries OCADml cairo2))
+ (libraries OCADml cairo2 unix))


### PR DESCRIPTION
It is used in the export module. You need to link it explicitly in ocaml >= 5.0